### PR TITLE
Added framing and buffered streams, and some testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ bytemuck = "1.23.1"
 libp2p = { version = "0.56.0", features = ["tokio", "quic", "gossipsub", "macros", "tcp", "dns", "noise", "yamux", "ping", "rsa"] }
 libp2p-stream = "0.4.0-alpha"
 tokio = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7", features = ["codec"] }
 tracing = "0.1.43"
 futures = "0.3.31"
 tracing-subscriber = { version = "0.3.22", features = ["std", "env-filter"] }

--- a/emp-bindings/build.rs
+++ b/emp-bindings/build.rs
@@ -20,7 +20,6 @@ fn main() {
     println!("cargo:rustc-link-lib=dylib=wrapper");
 
     // Include dependencies.
-
     println!("cargo:rustc-link-search=native={}", "/usr/local/lib");
     println!("cargo:rustc-link-lib=wrapper");
     println!("cargo:rustc-link-lib=emp-tool");

--- a/emp-bindings/src/constants.rs
+++ b/emp-bindings/src/constants.rs
@@ -1,9 +1,11 @@
+/// Wrapper for a Learning Parity with Noise parameter.
 #[repr(C)]
 pub(crate) struct PrimalLpnParameterWrapper {
     _private: [u8; 0],
 }
 
 extern "C" {
+    /// Creates a new Learning Parity with Noise parameter instance.
     pub(crate) fn new_primal_lpn_parameter(
         n: i64,
         t: i64,
@@ -15,14 +17,19 @@ extern "C" {
         log_bin_sz_pre: i64,
     ) -> *mut PrimalLpnParameterWrapper;
 
+    /// Deletes a Learning Parity with Noise parameter instance. This is necessary for the destructor
+    /// method.
     pub(crate) fn delete_primal_lpn_parameter(param: *mut PrimalLpnParameterWrapper);
 }
 
+/// Learning Parity with Noise parameter.
 pub struct PrimalLpnParameter {
+    /// Inner instance that wraps the C++ object.
     pub(crate) param: *mut PrimalLpnParameterWrapper,
 }
 
 impl PrimalLpnParameter {
+    /// Creates a new Learning Parity with Noise parameter instance.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         n: i64,

--- a/emp-bindings/src/countio.rs
+++ b/emp-bindings/src/countio.rs
@@ -1,24 +1,38 @@
 use std::ffi::CString;
 use std::os::raw::{c_char, c_int, c_void};
 
+/// Wrapper for the network IO channel.
 #[repr(C)]
 pub struct CountNetIoWrapper {
     _private: [u8; 0],
 }
 
 extern "C" {
+    /// Create a new network IO channel.
     fn new_count_net_io(
         address: *const c_char,
         port: c_int,
         quiet: usize,
     ) -> *mut CountNetIoWrapper;
+
+    /// Deletes the network IO channel. This is required for the destructor to work properly.
     fn delete_count_net_io(io: *const CountNetIoWrapper);
+
+    /// Get the number of bytes sent.
     fn count_net_io_get_bytes_sent(io: *const CountNetIoWrapper) -> usize;
+
+    /// Get the number of bytes received.
     fn count_net_io_get_bytes_recv(io: *const CountNetIoWrapper) -> usize;
+
+    /// Send data over the network IO channel.
     fn send_data_internal(io: *mut CountNetIoWrapper, data: *mut c_void, len: usize);
+
+    /// Receives data from the network IO channel.
     fn recv_data_internal(io: *mut CountNetIoWrapper, data: *mut c_void, len: usize);
 }
 
+/// A network IO channel that can be used for sending and receiving data over the network. This
+/// network implementation counts the number of bytes sent and received.
 #[derive(Debug, Clone)]
 pub struct CountNetIo {
     pub ptr: *mut CountNetIoWrapper,
@@ -39,24 +53,29 @@ impl CountNetIo {
         Self { ptr }
     }
 
+    /// Gets the number of bytes sent.
     pub fn bytes_sent(&self) -> usize {
         unsafe { count_net_io_get_bytes_sent(self.ptr) }
     }
 
+    /// Gets the number of bytes received.
     pub fn bytes_recv(&self) -> usize {
         unsafe { count_net_io_get_bytes_recv(self.ptr) }
     }
 
+    /// Gets a pointer to the underlying network instance.
     pub fn as_ptr(&self) -> *mut CountNetIoWrapper {
         self.ptr
     }
 
+    /// Sends data to the other party using the network channel.
     pub fn send_data(&self, data: &mut [u64]) {
         unsafe {
             send_data_internal(self.ptr, data.as_mut_ptr() as *mut c_void, data.len() * 8);
         }
     }
 
+    /// Receives data from the other party using the network channel.
     pub fn recv_data(&self, data: &mut [u64]) {
         unsafe {
             recv_data_internal(self.ptr, data.as_mut_ptr() as *mut c_void, data.len() * 8);

--- a/emp-bindings/src/lib.rs
+++ b/emp-bindings/src/lib.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::thread;
 use std::time::Instant;
-
+use tracing::info;
 #[allow(unused_imports)]
 use tracing_subscriber::{fmt, EnvFilter};
 
@@ -23,22 +23,26 @@ pub mod constants;
 pub mod countio;
 pub mod utils;
 
+/// Wrapper for the OLE over F2k.
 #[repr(C)]
 pub(crate) struct OleF2kWrapper {
     _private: [u8; 0],
 }
 
+/// Wrapper for the OLE over Z2k.
 #[repr(C)]
 pub(crate) struct OleZ2kWrapper {
     _private: [u8; 0],
 }
 
+/// Wrapper for the Ferret COT instance.
 #[repr(C)]
 pub(crate) struct FerretCotWrapper {
     _private: [u8; 0],
 }
 
 extern "C" {
+    /// Creates a new instance of the OLE over F2k.
     pub(crate) fn new_ole_f2k(CountNetIoWrapper: *mut CountNetIoWrapper) -> *mut OleF2kWrapper;
 
     pub(crate) fn inner_prod_ole_f2k(
@@ -49,6 +53,7 @@ extern "C" {
         sz: i32,
     );
 
+    /// Computes the OLE over F2k.
     pub(crate) fn compute_ole_f2k(
         ole: *mut OleF2kWrapper,
         out: *mut BlockWrapper,
@@ -56,8 +61,10 @@ extern "C" {
         length: i32,
     );
 
+    /// Deletes the OLE over F2k instance. This is required for the destructor to work properly.
     pub(crate) fn delete_ole_f2k(ole: *mut OleF2kWrapper);
 
+    /// Creates a new instance of the Ferret COT.
     pub(crate) fn new_ferret_cot(
         party: u32,
         threads: u32,
@@ -69,16 +76,20 @@ extern "C" {
         pre_file: *const c_char,
     ) -> *mut FerretCotWrapper;
 
+    /// Deletes the Ferret COT instance. This is required for the destructor to work properly.
     pub(crate) fn delete_ferret_cot(ios: *mut FerretCotWrapper);
 
+    /// Creates a new instance of the OLE over Z2k.
     pub(crate) fn new_ole_z2k(
         net_io_wrapper: *mut CountNetIoWrapper,
         cot: *mut FerretCotWrapper,
         bitlength: usize,
     ) -> *mut OleZ2kWrapper;
 
+    /// Deletes the OLE over Z2k instance. This is required for the destructor to work properly.
     pub(crate) fn delete_ole_z2k(net_io_wrapper: *mut OleZ2kWrapper);
 
+    /// Computes the OLE over Z2k.
     pub(crate) fn compute_ole_z2k(
         ole: *mut OleZ2kWrapper,
         out: *mut u64,
@@ -159,6 +170,7 @@ impl Drop for OleZ2k {
     }
 }
 
+/// API for the Ferret COT.
 pub struct FerretCot {
     inner_cot: *mut FerretCotWrapper,
     // Keep these alive as long as inner_cot is alive
@@ -170,6 +182,7 @@ unsafe impl Send for FerretCot {}
 unsafe impl Sync for FerretCot {}
 
 impl FerretCot {
+    /// Creates a new Ferret COT instance.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         party: u32,
@@ -224,9 +237,10 @@ pub fn read_ip_list(filename: &str, total_party: usize) -> Result<Vec<String>, s
     Ok(ip_list)
 }
 
+/// Maximum batch size for the OLE computation.
 const MAX_BATCH_SIZE: usize = 100_000;
 
-/// Generate `num_triples` Beaver triples
+/// Generate `num_triples` Beaver triples.
 #[allow(clippy::type_complexity)]
 pub fn generate_triples(
     party: usize,
@@ -237,6 +251,8 @@ pub fn generate_triples(
 ) -> Result<Vec<(u64, u64, u64)>, Box<dyn std::error::Error>> {
     assert!(party < total_party);
     assert_eq!(ip_list.len(), total_party);
+
+    info!(id = party, "Starting triple generation");
 
     // Initialize CountNetIO channels
     let start_io = Instant::now();
@@ -366,7 +382,7 @@ pub fn generate_triples(
     }
 
     let duration = start.elapsed();
-    tracing::info!(
+    info!(
         "[Party {}]: COT Initialization complete. Time taken: {} microseconds",
         party,
         duration.as_micros()
@@ -444,7 +460,7 @@ pub fn generate_triples(
     }
 
     let duration_comp = start_comp.elapsed();
-    tracing::info!(
+    info!(
         "[Party {}]: Computation complete. Time taken: {} microseconds",
         party,
         duration_comp.as_micros()
@@ -462,7 +478,7 @@ pub fn generate_triples(
         writeln!(ofile, "a: {}, b: {}, c: {}", in_a[i], in_b[i], out[i])?;
     }
     let duration_file = start_file.elapsed();
-    tracing::info!(
+    info!(
         "[Party {}]: File writing complete. Time taken: {} microseconds",
         party,
         duration_file.as_micros()

--- a/emp-bindings/src/utils.rs
+++ b/emp-bindings/src/utils.rs
@@ -1,18 +1,23 @@
+/// Wrapper for a block of 128-bit data.
 #[repr(C, align(16))]
 pub(crate) struct BlockWrapper {
     inner_block: [u8; 16],
 }
 
 extern "C" {
+    /// Creates a new block of 128-bit data.
     pub(crate) fn new_block(inner_block: *const u8) -> *mut BlockWrapper;
+    /// Deletes the block of 128-bit data. This is required for the destructor to work properly.
     pub(crate) fn delete_block(block: *mut BlockWrapper);
 }
 
+/// API for a block of 128-bit data.
 pub struct Block {
     pub(crate) inner_block: *mut BlockWrapper,
 }
 
 impl Block {
+    /// Creates a new block of 128-bit data.
     pub fn new(data: [u8; 16]) -> Self {
         let inner_block = unsafe { new_block(data.as_ptr()) };
         Self { inner_block }

--- a/emp-bindings/triples/CMakeLists.txt
+++ b/emp-bindings/triples/CMakeLists.txt
@@ -21,27 +21,27 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 find_package(OpenSSL REQUIRED)
 if (NOT OpenSSL_FOUND)
     message(FATAL_ERROR "OpenSSL not found. Install it via: sudo apt-get install -y libssl-dev")
-endif()
+endif ()
 
 # ===== Library definition =====
 add_library(wrapper SHARED
-    src/wrapper.cpp
-    src/utils.cpp
-    src/constants.cpp
-    src/countio.cpp
-    internal/wrapper_internal.hpp
+        src/wrapper.cpp
+        src/utils.cpp
+        src/constants.cpp
+        src/countio.cpp
+        internal/wrapper_internal.hpp
 )
 
 target_include_directories(wrapper
-    PUBLIC
+        PUBLIC
         "${CMAKE_SOURCE_DIR}/include"
-    PRIVATE
+        PRIVATE
         "${CMAKE_SOURCE_DIR}/internal"
 )
 
 # ===== Link dependencies =====
 target_link_libraries(wrapper
-    PRIVATE
+        PRIVATE
         ${EMP-OT_LIBRARIES}
         OpenSSL::Crypto
 )
@@ -50,9 +50,9 @@ target_link_libraries(wrapper
 include(GNUInstallDirs)
 install(DIRECTORY src DESTINATION include)
 install(TARGETS wrapper
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
 # ===== Enable and add tests =====

--- a/emp-bindings/triples/internal/ole_f2k.h
+++ b/emp-bindings/triples/internal/ole_f2k.h
@@ -14,7 +14,7 @@ public:
     }
 
     /* Compute the inner product of two block vectors*/
-    void inner_prod(block *res, const block *a, const block *b, int sz) {
+    static void inner_prod(block *res, const block *a, const block *b, int sz) {
         block r = zero_block;
         block r1;
         for (int i = 0; i < sz; i++) {
@@ -26,9 +26,9 @@ public:
 
     /* Compute the OLE protocol with inputs in, and put the output to out */
     void compute(block *out, const block *in, int length) {
-        block *raw0 = new block[length * 128];
+        auto *raw0 = new block[length * 128];
         if (!cmpBlock(&ot->Delta, &zero_block, 1)) {
-            block *raw1 = new block[length * 128];
+            auto *raw1 = new block[length * 128];
             ot->send_rot(raw0, raw1, length * 128);
             for (int i = 0; i < length; ++i) {
                 for (int j = 0; j < 128; ++j) {
@@ -39,7 +39,7 @@ public:
             }
             delete[] raw1;
         } else {
-            bool *bits = new bool[length * 128];
+            auto bits = new bool[length * 128];
             for (int i = 0; i < length; ++i)
                 block_to_bool(bits + i * 128, in[i]);
 

--- a/emp-bindings/triples/internal/ole_z2k.h
+++ b/emp-bindings/triples/internal/ole_z2k.h
@@ -10,18 +10,18 @@ public:
     COT<IO> *ot;
     CCRH ccrh;
     size_t bit_length;
-    OLEZ2K(IO *io, COT<IO> *ot, size_t bit_length) : 
+    OLEZ2K(IO *io, COT<IO> *ot, const size_t bit_length) :
         io(io), ot(ot), bit_length(bit_length) {
     }
 
     /* Compute the OLE protocol */
-    void compute(uint64_t *out, const uint64_t *in, size_t length, size_t cot_batch_size = 128) {
-        block *raw = new block[cot_batch_size * bit_length];
-        uint64_t *msg = new uint64_t[bit_length];
+    void compute(uint64_t *out, const uint64_t *in, const size_t length, const size_t cot_batch_size = 128) {
+        auto *raw = new block[cot_batch_size * bit_length];
+        auto *msg = new uint64_t[bit_length];
         size_t remain_length = length;
         PRG prg;
         if (!cmpBlock(&ot->Delta, &zero_block, 1)) {
-            block *pad = new block[bit_length << 1];
+            auto *pad = new block[bit_length << 1];
             while (remain_length > 0) {
                 size_t current_length = std::min(remain_length, cot_batch_size);
                 remain_length -= current_length;
@@ -44,10 +44,10 @@ public:
             delete[] pad;
         }
         else {
-            block *pad = new block[bit_length];
-            bool *bits = new bool[cot_batch_size * bit_length];
+            auto *pad = new block[bit_length];
+            auto bits = new bool[cot_batch_size * bit_length];
             while (remain_length > 0) {
-                size_t current_length = std::min(remain_length, cot_batch_size);
+                const size_t current_length = std::min(remain_length, cot_batch_size);
                 remain_length -= current_length;
                 for (size_t i = 0; i < current_length; ++i) {
                     for (size_t j = 0; j < bit_length; ++j) {

--- a/mpc/Cargo.toml
+++ b/mpc/Cargo.toml
@@ -19,6 +19,7 @@ log = "0.4.28"
 
 [dev-dependencies]
 thfhe = { path = "../thfhe" }
+concrete-ntt = "0.2.0"
 
 [features]
 default = ["concrete-ntt"]

--- a/mpc/src/dn.rs
+++ b/mpc/src/dn.rs
@@ -16,10 +16,12 @@ use rand::distributions::Uniform;
 use rand::prelude::*;
 use rand::{RngCore, SeedableRng};
 use std::collections::{HashMap, VecDeque};
+use std::fmt::{Debug, Formatter};
 use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, Notify};
+use tracing::{info, instrument};
 
 mod matrix;
 
@@ -79,8 +81,29 @@ pub struct DNBackend<const P: u64> {
     mul_count_z2k: u32,
 }
 
+impl<const P: u64> Debug for DNBackend<P> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DNBackend")
+            .field("party_id", &self.party_id)
+            .field("num_parties", &self.num_parties)
+            .field("num_threshold", &self.num_threshold)
+            .finish()
+    }
+}
+
 impl<const P: u64> DNBackend<P> {
     /// Creates a new DN07 backend instance.
+    ///
+    /// # Arguments
+    ///
+    /// - `party_id`: The ID of the current party.
+    /// - `num_parties`: Number of total parties participating in the protocol.
+    /// - `num_threshold`: Threshold of corrupted parties.
+    /// - `triple_required`: (?).
+    /// - `node_config`: Configuration of the node represented with a [`NodeConfig`] instance.
+    /// - `polynomial_size`: (?).
+    /// - `need_mult_init`: (?).
+    /// - `need_prg_init`: (?).
     #[allow(clippy::too_many_arguments)]
     pub async fn new(
         party_id: usize,
@@ -104,6 +127,7 @@ impl<const P: u64> DNBackend<P> {
         // Setup network and PRG instances
         let mut prg = Prg::new();
 
+        // Sets up the P2P network.
         let (received_broadcasts_sender, received_broadcasts_receiver) =
             tokio::sync::mpsc::channel(100);
         let network_ready = Arc::new(Notify::new());
@@ -122,9 +146,11 @@ impl<const P: u64> DNBackend<P> {
 
         let shared_prg =
             Self::setup_shared_prg(party_id, num_parties, &mut prg, Arc::clone(&netio)).await;
-        // Calculate appropriate buffer size (rounded up to next multiple of (n-t))
+
+        // Calculate the appropriate buffer size (rounded up to the next multiple of (n-t))
         let batch_size = (num_parties - num_threshold) as usize;
         let buffer_size = (triple_required as usize).div_ceil(batch_size) * batch_size;
+
         // Create and initialize the backend
         let mut backend = Self {
             party_id,
@@ -158,18 +184,13 @@ impl<const P: u64> DNBackend<P> {
             mul_count_z2k: 0,
         };
 
-        // Generate initial supply of triples
-        // backend.generate_triples(buffer_size);
-        // backend
-
-        // Generate initial supply of triples
+        // Generate the initial supply of triples.
         backend.init_shamir_to_additive_vec_z2k();
         if need_prg_init {
             backend.init_pair_to_pair_prg().await;
         }
 
         if need_mul_init {
-            //backend.init_shamir_to_additive_vec_z2k();
             backend.generate_double_randoms(buffer_size).await;
         }
 
@@ -187,7 +208,7 @@ impl<const P: u64> DNBackend<P> {
     }
 
     /// Builds the Vandermonde matrix for polynomial evaluation at party positions.
-    fn build_vandermonde_matrix(num_parties: u32, positions: &[u64]) -> Vec<Vec<u64>> {
+    pub fn build_vandermonde_matrix(num_parties: u32, positions: &[u64]) -> Vec<Vec<u64>> {
         let mut matrix = Vec::with_capacity(num_parties as usize);
         // First row: all 1's
         matrix.push(vec![1; num_parties as usize]);
@@ -295,7 +316,6 @@ impl<const P: u64> DNBackend<P> {
 
                 if pid != my_pid {
                     let data = bytemuck::cast_slice(&share_column);
-                    //let _ = self.send_with_retry(&netio, self.party_id, data, 1000);
                     netio.send(pid, data).await.expect("Send failed");
                     netio.flush(pid).await.expect("Flush failed");
                 } else {
@@ -509,7 +529,8 @@ impl<const P: u64> DNBackend<P> {
         }
     }
 
-    fn inverse_vandermonde_mod_p(&mut self, vander: Vec<Vec<u64>>) -> Vec<Vec<u64>> {
+    /// Computes the inverse of the Vandermonde matrix modulo a prime [`P`].
+    pub fn inverse_vandermonde_mod_p(vander: Vec<Vec<u64>>) -> Vec<Vec<u64>> {
         let n = vander.len();
         let mut x = Vec::with_capacity(n);
         for row in vander.iter().take(n) {
@@ -984,6 +1005,7 @@ impl<const P: u64> DNBackend<P> {
         }
     }
 
+    #[instrument(skip_all)]
     async fn open_secrets_parallel(
         &mut self,
         reconstructor_id: usize,
@@ -991,6 +1013,7 @@ impl<const P: u64> DNBackend<P> {
         shares: &[u64],
         broadcast_result: bool,
     ) -> Option<Vec<u64>> {
+        info!("Opening a slice of secrets in parallel");
         let lagrange_coef = match degree {
             d if d == self.num_threshold => &self.lagrange_coeffs.0,
             d if d == (self.num_threshold * 2) => &self.lagrange_coeffs.1,
@@ -1583,7 +1606,7 @@ impl<const P: u64> DNBackend<P> {
 
         //println!("self.van_matrix:{:?}", self.van_matrix);
         //println!("matrix: {:?} ",matrix);
-        self.reverse_vander_matrix = self.inverse_vandermonde_mod_p(matrix);
+        self.reverse_vander_matrix = Self::inverse_vandermonde_mod_p(matrix);
         let temp = Matrix::transposed_sub_matrix_with_data(
             &self.van_matrix,
             0,
@@ -1606,7 +1629,7 @@ impl<const P: u64> DNBackend<P> {
         }
 
         //println!("van_t: {:?} ",van_t);
-        for x in self.inverse_vandermonde_mod_p(van_t)[0].iter() {
+        for x in Self::inverse_vandermonde_mod_p(van_t)[0].iter() {
             self.pre_shamir_to_additive_vec.push(*x);
         }
     }
@@ -1989,7 +2012,9 @@ impl<const P: u64> MPCBackend for DNBackend<P> {
         Ok(result[0])
     }
 
+    #[instrument(skip_all)]
     async fn reveal_slice_to_all(&mut self, shares: &[Self::Sharing]) -> MPCResult<Vec<u64>> {
+        info!(id = self.party_id, "Revealing slice to all parties");
         let results = self
             .open_secrets_parallel(0, self.num_threshold, shares, true)
             .await
@@ -2018,6 +2043,7 @@ impl<const P: u64> MPCBackend for DNBackend<P> {
         self.uniform_distr.sample(&mut self.shared_prg)
     }
 
+    #[instrument(skip_all)]
     fn shared_rand_field_elements(&mut self, destination: &mut [u64]) {
         destination
             .iter_mut()
@@ -2318,6 +2344,7 @@ impl<const P: u64> MPCBackend for DNBackend<P> {
         batch_size: usize,
         party_id: usize,
     ) -> Vec<u64> {
+        info!(self_id = self.party_id(), "Sending slice to all parties");
         let all_shares = if self.party_id == party_id {
             let temp: Vec<Vec<u64>> = values
                 .unwrap()
@@ -2373,17 +2400,19 @@ impl<const P: u64> MPCBackend for DNBackend<P> {
         Ok(shares)
     }
 
+    #[instrument(skip_all)]
     async fn all_paries_sends_slice_to_all_parties_sum(
         &self,
         values: &[u64],
         batch_size: usize,
         sum_result: &mut [Self::Sharing],
     ) {
+        info!(self_id = self.party_id(), "Sending slice to all parties");
         let (tx, rx) = channel::unbounded::<Vec<u64>>();
         for i in 0..self.num_parties {
             let tx_clone = tx.clone();
             let values = values.to_vec();
-            let party_id = self.party_id();
+            let party_id = self.party_id;
 
             let result = if i == self.party_id {
                 self.input_slice(Some(&values), batch_size, party_id)
@@ -2406,14 +2435,12 @@ impl<const P: u64> MPCBackend for DNBackend<P> {
             };
         }
         drop(tx);
-        //s.spawn(move || {
         for res in rx.iter() {
             sum_result
                 .iter_mut()
                 .zip(res.iter())
                 .for_each(|(e, res)| *e = self.add_const(*e, *res));
         }
-        //});
     }
 
     /// count times

--- a/mpc/src/dn.rs
+++ b/mpc/src/dn.rs
@@ -1895,6 +1895,8 @@ impl<const P: u64> MPCBackend for DNBackend<P> {
             return Err(MPCErr::ProtocolError("Invalid party ID".into()));
         }
 
+        info!(id = self.party_id, "Inputting slice");
+
         let shares = if self.party_id == party_id {
             self.generate_shares_streaming_and_send(
                 values.expect("Dealer must provide values"),
@@ -2023,10 +2025,15 @@ impl<const P: u64> MPCBackend for DNBackend<P> {
         Ok(results)
     }
 
+    #[instrument(skip_all)]
     async fn reveal_slice_degree_2t_to_all(
         &mut self,
         shares: &[Self::Sharing],
     ) -> MPCResult<Vec<u64>> {
+        info!(
+            id = self.party_id,
+            "Revealing slice of degree 2t to all parties"
+        );
         let results = self
             .open_secrets_parallel(0, self.num_threshold * 2, shares, true)
             .await
@@ -2043,7 +2050,6 @@ impl<const P: u64> MPCBackend for DNBackend<P> {
         self.uniform_distr.sample(&mut self.shared_prg)
     }
 
-    #[instrument(skip_all)]
     fn shared_rand_field_elements(&mut self, destination: &mut [u64]) {
         destination
             .iter_mut()
@@ -2400,6 +2406,7 @@ impl<const P: u64> MPCBackend for DNBackend<P> {
         Ok(shares)
     }
 
+    /// Computes shares of a slice and sums it to the `sum_result`.
     #[instrument(skip_all)]
     async fn all_paries_sends_slice_to_all_parties_sum(
         &self,
@@ -2408,7 +2415,7 @@ impl<const P: u64> MPCBackend for DNBackend<P> {
         sum_result: &mut [Self::Sharing],
     ) {
         info!(self_id = self.party_id(), "Sending slice to all parties");
-        let (tx, rx) = channel::unbounded::<Vec<u64>>();
+        let (tx, mut rx) = tokio::sync::mpsc::channel(128);
         for i in 0..self.num_parties {
             let tx_clone = tx.clone();
             let values = values.to_vec();
@@ -2424,23 +2431,27 @@ impl<const P: u64> MPCBackend for DNBackend<P> {
 
             if i == self.party_id {
                 tokio::spawn(async move {
-                    tx_clone.send(result).unwrap();
+                    tx_clone.send(result).await.unwrap();
                     drop(tx_clone);
                 });
             } else if i != self.party_id {
                 tokio::spawn(async move {
-                    tx_clone.send(result).unwrap();
+                    tx_clone.send(result).await.unwrap();
                     drop(tx_clone);
                 });
             };
         }
         drop(tx);
-        for res in rx.iter() {
+        while let Some(res) = rx.recv().await {
             sum_result
                 .iter_mut()
                 .zip(res.iter())
-                .for_each(|(e, res)| *e = self.add_const(*e, *res));
+                .for_each(|(e, res)| *e = self.add(*e, *res));
         }
+        info!(
+            self_id = self.party_id(),
+            "Finished share slice to all parties and sum"
+        );
     }
 
     /// count times
@@ -2468,7 +2479,7 @@ impl<const P: u64> MPCBackend for DNBackend<P> {
         batch_size: usize,
         sum_result: &mut [Self::Sharing],
     ) {
-        let (tx, rx) = channel::unbounded::<Vec<u64>>();
+        let (tx, mut rx) = tokio::sync::mpsc::channel(128);
         for i in 0..self.num_parties {
             let tx_clone = tx.clone();
             let values = values.to_vec();
@@ -2489,12 +2500,12 @@ impl<const P: u64> MPCBackend for DNBackend<P> {
             };
 
             tokio::spawn(async move {
-                tx_clone.send(result).unwrap();
+                tx_clone.send(result).await.unwrap();
                 drop(tx_clone);
             });
         }
         drop(tx);
-        for res in rx.iter() {
+        while let Some(res) = rx.recv().await {
             sum_result
                 .iter_mut()
                 .zip(res.iter())

--- a/mpc/src/dn/matrix.rs
+++ b/mpc/src/dn/matrix.rs
@@ -1,6 +1,6 @@
 use algebra::{Field, U64FieldEval};
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Matrix {
     pub data: Vec<Vec<u64>>,
 }

--- a/mpc/tests/dn.rs
+++ b/mpc/tests/dn.rs
@@ -913,7 +913,6 @@ fn vandermonde_matrix_and_inverse_correctness() {
     let inverse_vandermonde_matrix =
         DNBackend::<PRIME>::inverse_vandermonde_mod_p(vandermonde_matrix.clone());
     let product = matrix_multiply(&vandermonde_matrix, &inverse_vandermonde_matrix);
-    println!("{:?}", product);
     assert!(is_identity_matrix(&product));
 }
 

--- a/mpc/tests/dn.rs
+++ b/mpc/tests/dn.rs
@@ -1,22 +1,26 @@
+use algebra::random::Prg;
+use algebra::reduce::ModulusValue::Prime;
 use algebra::{Field, U64FieldEval};
+use concrete_ntt::prime64::Plan;
 use libp2p::identity::Keypair;
 use libp2p::{Multiaddr, PeerId};
 use mpc::{DNBackend, MPCBackend};
 use network::p2p::NodeConfig;
-use rand::{random, Rng};
+use rand::{Rng, RngCore};
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::Duration;
 use thfhe::sqrt_mod_p;
 use tokio::sync::Mutex;
-use tracing::{info, Level};
+use tracing::info;
 use tracing_subscriber::EnvFilter;
 
-// Prime field modulus for tests.
-const PRIME: u64 = 9007199254614017;
+/// Prime field modulus for tests.
+const PRIME: u64 = 7239467204018177;
 
+/// Global tracing initialization.
 static INIT: std::sync::Once = std::sync::Once::new();
 
+/// Sets up tracing for tests.
 pub fn setup_tracing() {
     INIT.call_once(|| {
         let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("off"));
@@ -625,14 +629,21 @@ async fn test_rand_coin_consistency() {
     }
 }
 
-#[ignore]
+/// Creates random elements and verifies that they are non-zero. A zero element is highly unlikely
+/// for a large enough field.
 #[tokio::test]
 async fn create_random_zero_elements_unlikely() {
     const NUM_PARTIES: usize = 4;
     const THRESHOLD: usize = 1;
     const BASE_PORT: usize = 50800;
+    const POLYNOMIAL_LENGTH: usize = 8192;
 
     const LENGTH_RANDOM_ELEMENTS: usize = 4096;
+
+    assert!(
+        Plan::try_new(POLYNOMIAL_LENGTH, PRIME).is_some(),
+        "Polynomial length and prime modulus are not compatible for NTT"
+    );
 
     let mut handles = Vec::new();
     let key_pairs = (0..NUM_PARTIES)
@@ -674,7 +685,7 @@ async fn create_random_zero_elements_unlikely() {
                 10,
                 node_config,
                 remote_peers,
-                1024,
+                POLYNOMIAL_LENGTH,
                 true,
                 true,
             )
@@ -701,7 +712,8 @@ async fn create_random_zero_elements_unlikely() {
     }
 }
 
-#[ignore]
+/// Creates random square elements and verifies that they are non-zero. A zero element is highly
+/// unlikely for a large enough field.
 #[tokio::test]
 async fn square_random_zero_elements_unlikely() {
     const NUM_PARTIES: usize = 10;
@@ -781,7 +793,6 @@ async fn square_random_zero_elements_unlikely() {
     }
 }
 
-#[ignore]
 #[tokio::test]
 async fn reveal_slice_to_all_correctness() {
     setup_tracing();
@@ -789,6 +800,7 @@ async fn reveal_slice_to_all_correctness() {
     const NUM_PARTIES: usize = 10;
     const THRESHOLD: usize = 2;
     const BASE_PORT: usize = 50900;
+    const POLYNOMIAL_SIZE: usize = 8192;
 
     const LENGTH_RANDOM_ELEMENTS: usize = 4096;
 
@@ -799,16 +811,11 @@ async fn reveal_slice_to_all_correctness() {
         .map(|_| Keypair::generate_ed25519())
         .collect::<Vec<_>>();
 
-    let mut random_elements = [0u64; LENGTH_RANDOM_ELEMENTS];
-    for i in 0..LENGTH_RANDOM_ELEMENTS {
-        random_elements[i] = rand::random::<u64>() % PRIME;
-    }
-
-    let random_elements = Arc::new(random_elements);
+    let elements = Arc::new([2u64; LENGTH_RANDOM_ELEMENTS]);
 
     for id in 0..NUM_PARTIES {
         let key_pairs = key_pairs.clone();
-        let random_elements = random_elements.clone();
+        let elements = elements.clone();
         handles.push(tokio::spawn(async move {
             // Set up the DN backend.
             let listen_addr =
@@ -842,7 +849,7 @@ async fn reveal_slice_to_all_correctness() {
                 10,
                 node_config,
                 remote_peers,
-                1024,
+                POLYNOMIAL_SIZE,
                 true,
                 true,
             )
@@ -850,20 +857,20 @@ async fn reveal_slice_to_all_correctness() {
             .unwrap();
 
             let input = if id == DEALER_IDX {
-                Some(&random_elements[..])
+                Some(&elements[..])
             } else {
                 None
             };
             let shares = backend
-                .input_slice(input, random_elements.len(), DEALER_IDX)
+                .input_slice(input, elements.len(), DEALER_IDX)
                 .await
                 .unwrap();
             info!("Input from Party {}: {:?}", id, input);
 
             let revealed_element = backend.reveal_slice_to_all(&shares).await.unwrap();
             info!("Revealed element for Party {}: {:?}", id, revealed_element);
-            for (revealed, original) in revealed_element.iter().zip(random_elements.iter()) {
-                assert_eq!(*revealed, *original);
+            for (revealed, original) in revealed_element.into_iter().zip(elements.into_iter()) {
+                assert_eq!(revealed, original);
             }
 
             true
@@ -874,4 +881,77 @@ async fn reveal_slice_to_all_correctness() {
     for handle in handles {
         assert!(handle.await.unwrap());
     }
+}
+
+#[test]
+fn bytemuck_viability() {
+    const NUM_VALUES: usize = 4096;
+    let field_mask = u64::MAX >> PRIME.leading_zeros();
+    let mut prg = Prg::new();
+    let random_values = (0..NUM_VALUES)
+        .map(|_| loop {
+            let r = prg.next_u64() & field_mask;
+            if r < PRIME {
+                break r;
+            }
+        })
+        .collect::<Vec<u64>>();
+
+    let bytes: &[u8] = bytemuck::cast_slice(&random_values);
+    let reconstructed_values: Vec<u64> = bytemuck::cast_slice(bytes).to_vec();
+    assert_eq!(random_values, reconstructed_values);
+}
+
+#[test]
+fn vandermonde_matrix_and_inverse_correctness() {
+    setup_tracing();
+    const NUM_PARTIES: usize = 10;
+    let party_positions: Vec<u64> = (1..=NUM_PARTIES as u64).collect();
+    let transpose_vandermonde_matrix =
+        DNBackend::<PRIME>::build_vandermonde_matrix(NUM_PARTIES as u32, &party_positions);
+    let vandermonde_matrix = transpose_matrix(&transpose_vandermonde_matrix);
+    let inverse_vandermonde_matrix =
+        DNBackend::<PRIME>::inverse_vandermonde_mod_p(vandermonde_matrix.clone());
+    let product = matrix_multiply(&vandermonde_matrix, &inverse_vandermonde_matrix);
+    println!("{:?}", product);
+    assert!(is_identity_matrix(&product));
+}
+
+fn transpose_matrix(matrix: &Vec<Vec<u64>>) -> Vec<Vec<u64>> {
+    let mut transposed_matrix = vec![vec![0; matrix.len()]; matrix[0].len()];
+    for (i, row) in matrix.iter().enumerate() {
+        for (j, value) in row.iter().enumerate() {
+            transposed_matrix[j][i] = *value;
+        }
+    }
+    transposed_matrix
+}
+
+fn is_identity_matrix(matrix: &Vec<Vec<u64>>) -> bool {
+    for i in 0..matrix.len() {
+        for j in 0..matrix[0].len() {
+            if i != j && matrix[i][j] != 0 {
+                return false;
+            } else if i == j && matrix[i][j] != 1 {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+fn matrix_multiply(matrix_a: &Vec<Vec<u64>>, matrix_b: &Vec<Vec<u64>>) -> Vec<Vec<u64>> {
+    assert_eq!(matrix_a[0].len(), matrix_b.len());
+    let mut result = vec![vec![0; matrix_a.len()]; matrix_b[0].len()];
+    for i in 0..matrix_a.len() {
+        for j in 0..matrix_b[0].len() {
+            for k in 0..matrix_a[0].len() {
+                result[i][j] = U64FieldEval::<PRIME>::add(
+                    result[i][j],
+                    U64FieldEval::<PRIME>::mul(matrix_a[i][k], matrix_b[k][j]),
+                );
+            }
+        }
+    }
+    result
 }

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -11,6 +11,9 @@ dashmap.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+rand.workspace = true
+tokio-util.workspace = true
 
 [dev-dependencies]
 serial_test.workspace = true
+bytemuck.workspace = true

--- a/network/src/p2p/mod.rs
+++ b/network/src/p2p/mod.rs
@@ -72,13 +72,15 @@ const PING_MAX_TIME_OUT: Duration = Duration::from_mins(15);
 /// Duration between two pings.
 const PING_INTERVAL: Duration = Duration::from_secs(10);
 
-/// Byte used to signal that a party received a opening stream request and that the party has added
+/// Byte used to signal that a party received an opening stream request and that the party has added
 /// the stream to its internal database.
 const ACK_BYTE: u8 = 0x06;
 
 /// Error type for the P2P network.
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
+    #[error("IO error: {0:?}")]
+    Io(#[from] std::io::Error),
     /// The behavior was not attached correctly to the swarm.
     #[error("infallible error: {0:?}")]
     Infallible(#[from] std::convert::Infallible),
@@ -119,6 +121,11 @@ pub enum Error {
         /// Error description.
         error: futures::io::Error,
     },
+    #[error("mismatch between the received data length ({received_data_length}) and the buffer length ({buffer_length})")]
+    BufferLengthMismatch {
+        received_data_length: usize,
+        buffer_length: usize,
+    },
     /// Error when subscribing to the default topic.
     #[error("error while subscribing to the default topic: {0:?}")]
     DefaultSubscriptionError(#[from] SubscriptionError),
@@ -129,9 +136,6 @@ pub enum Error {
     #[error("error while broadcasting the message: {0:?}")]
     BroadcastError(#[from] PublishError),
     /// Error when flushing the channel.
-    #[error("error flushing the channel: {0:?}")]
-    FlushError(#[from] futures::io::Error),
-    /// Error joining the tasks.
     #[error("error joining the tasks: {0:?}")]
     JoinError(#[from] JoinError),
     /// Undesired swarm event.
@@ -186,7 +190,7 @@ pub struct NodeConfig {
 impl NodeConfig {
     /// Creates a new configuration for the node.
     ///
-    /// The `listen_addresses` are the addresses that the node will use to listen for incomming
+    /// The `listen_addresses` are the addresses that the node will use to listen for incoming
     /// communication, and the `keypair` is the public/private keys to secure the communication.
     pub fn new(listen_addresses: Vec<Multiaddr>, keypair: Keypair) -> Self {
         Self {
@@ -240,6 +244,90 @@ pub enum SwarmCommand {
     ShutDown,
 }
 
+/// A buffered stream based on a [`Stream`].
+#[derive(Debug)]
+pub struct BufferedFramedStream {
+    stream: Stream,
+    buffer: Vec<u8>,
+}
+
+impl BufferedFramedStream {
+    /// Size of the header of a frame.
+    pub const HEADER_BYTE_SIZE: usize = 4;
+
+    pub const DEFAULT_TEMP_BUFFER_SIZE: usize = 4096;
+
+    /// Creates a new buffered stream based on a [`Stream`].
+    pub fn new(stream: Stream) -> Self {
+        Self {
+            stream,
+            buffer: Vec::new(),
+        }
+    }
+
+    pub async fn read(&mut self, buf: &mut [u8]) -> Result<()> {
+        while self.buffer.len() < Self::HEADER_BYTE_SIZE {
+            self.get_more_bytes_from_stream().await?;
+        }
+
+        let mut header: [u8; Self::HEADER_BYTE_SIZE] = [0u8; Self::HEADER_BYTE_SIZE];
+        header.copy_from_slice(&self.buffer[..Self::HEADER_BYTE_SIZE]);
+        let bytes_to_read = u32::from_be_bytes(header);
+
+        while self.buffer.len() < Self::HEADER_BYTE_SIZE + bytes_to_read as usize {
+            self.get_more_bytes_from_stream().await?;
+        }
+
+        // If the input buffer is too small to fit the received data, we clear the stream buffer up
+        // to the incoming message and return an error.
+        if bytes_to_read > buf.len() as u32 {
+            self.buffer
+                .drain(..Self::HEADER_BYTE_SIZE + (bytes_to_read as usize));
+            return Err(Error::BufferLengthMismatch {
+                received_data_length: bytes_to_read as usize,
+                buffer_length: buf.len(),
+            });
+        }
+
+        let complete_frame = self
+            .buffer
+            .drain(..Self::HEADER_BYTE_SIZE + (bytes_to_read as usize))
+            .collect::<Vec<u8>>();
+
+        buf.copy_from_slice(
+            &complete_frame[Self::HEADER_BYTE_SIZE..Self::HEADER_BYTE_SIZE + buf.len()],
+        );
+
+        Ok(())
+    }
+
+    pub async fn write(&mut self, buf: &[u8]) -> Result<()> {
+        let header: &[u8; Self::HEADER_BYTE_SIZE] = &(buf.len() as u32).to_be_bytes();
+        self.stream.write_all(header).await?;
+        self.stream.write_all(buf).await?;
+        Ok(())
+    }
+
+    pub async fn flush(&mut self) -> Result<()> {
+        self.stream.flush().await?;
+        Ok(())
+    }
+
+    async fn get_more_bytes_from_stream(&mut self) -> std::io::Result<()> {
+        let mut temp_buffer = [0u8; Self::DEFAULT_TEMP_BUFFER_SIZE];
+        let bytes_read = self.stream.read(&mut temp_buffer).await?;
+        if bytes_read == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "stream closed",
+            ));
+        }
+
+        self.buffer.extend_from_slice(&temp_buffer[..bytes_read]);
+        Ok(())
+    }
+}
+
 /// A node in the network.
 ///
 /// The node is implemented as a manager to the [`libp2p::swarm::Swarm`]. In this case, this struct
@@ -249,13 +337,14 @@ pub enum SwarmCommand {
 /// a message, etc. Those actions may be executed asynchronously by the caller, and this struct
 /// manages all of these actions and passes them into the swarm. Once the action is performed, the
 /// node returns a response telling whether the command was executed successfully or not.
+#[derive(Debug)]
 pub struct P2pNet {
     /// ID of the node in the network.
     id: usize,
     /// Addresses used by this node to listen to new connections.
     listen_addresses: Vec<Multiaddr>,
     /// Current stablished connections.
-    streams: Arc<DashMap<PeerId, Arc<Mutex<Stream>>>>,
+    streams: Arc<DashMap<PeerId, Arc<Mutex<BufferedFramedStream>>>>,
     /// Map of integer IDs to network IDs
     peer_ids: Arc<DashMap<usize, PeerId>>,
     /// Stats for the network.
@@ -284,7 +373,7 @@ impl P2pNet {
         let peer_id = PeerId::from(config.keypair.public());
 
         let (sender_swarm_commands, mut receiver_swarm_commands) =
-            tokio::sync::mpsc::channel::<SwarmCommand>(64);
+            mpsc::channel::<SwarmCommand>(64);
 
         let peer_ids = DashMap::new();
         peer_ids.insert(party_idx, peer_id);
@@ -348,6 +437,8 @@ impl P2pNet {
 
         let (tx_connected_parties, mut rx_connected_parties) = mpsc::channel(100);
         let tx_connected_parties_listener = tx_connected_parties.clone();
+
+        // This task is in charge of receiving connections from remote parties.
         tokio::spawn(async move {
             info!(local_id = party_idx, "Listening for incoming streams");
             while let Some((peer, stream)) = incoming_streams_handler.next().await {
@@ -356,7 +447,8 @@ impl P2pNet {
 
                 // Spawn a new task to handle the new stream ACK response.
                 tokio::spawn(async move {
-                    let stream_ref = Arc::new(Mutex::new(stream));
+                    let buffered_stream = BufferedFramedStream::new(stream);
+                    let stream_ref = Arc::new(Mutex::new(buffered_stream));
                     let stream_for_ack = stream_ref.clone();
 
                     // We first add the stream to the database, and then we send an ACK message
@@ -367,7 +459,8 @@ impl P2pNet {
                     {
                         info!(
                             local_id = party_idx,
-                            "Storing stream in the database with remote peer {peer}"
+                            remote_peer = ?peer,
+                            "Storing stream in the database with remote peer"
                         );
                         if streams_clone.insert(peer, stream_ref).is_some() {
                             error!(local_id = party_idx, "The stream was already present in the database. The old stream will be dropped.");
@@ -382,7 +475,7 @@ impl P2pNet {
                         );
                         let mut stream_mutex = stream_for_ack.lock().await;
 
-                        match stream_mutex.write_all(&[ACK_BYTE]).await {
+                        match stream_mutex.write(&[ACK_BYTE]).await {
                             Ok(()) => {
                                 info!(
                                     local_id = party_idx,
@@ -420,7 +513,9 @@ impl P2pNet {
             );
         });
 
-        // Start a loop to listen for commands to the swarm.
+        // Start a loop to listen for commands to the swarm. This task models the Swarm as an actor
+        // that is modified through commands. In this way, we keep only one swarm for the whole
+        // execution.
         tokio::spawn(async move {
             loop {
                 tokio::select! {
@@ -458,16 +553,17 @@ impl P2pNet {
                                         let mut connection_attempts = 0;
                                         loop {
                                             match control.open_stream(peer_id, protocol.clone()).await {
-                                                Ok(mut stream) => {
+                                                Ok(stream) => {
                                                     // Wait to receive the ACK signal from the other side of the channel.
                                                     // The ACK signal confirms that the party on the other side of the
                                                     // stream has added this stream to its internal database.
+                                                    let mut buffered_stream = BufferedFramedStream::new(stream);
                                                     let mut ack_buffer = [0u8; 1];
                                                     info!(local_id = party_idx, "Waiting for ACK signal from peer {peer_id} to open a stream.");
-                                                    if let Err(e) = stream.read_exact(&mut ack_buffer).await {
+                                                    if let Err(e) = buffered_stream.read(&mut ack_buffer).await {
                                                         if connection_attempts >= MAX_CONNECTION_ATTEMPTS {
                                                             error!(local_id = party_idx, "Error receiving ACK signal from peer {peer_id}: {e:?}");
-                                                            let _ = response.send(Err(Error::StreamHandshakeError(e)));
+                                                            let _ = response.send(Err(e));
                                                             return;
                                                         } else {
                                                             warn!(local_id = party_idx, "Error receiving ACK signal from peer {peer_id}: {e:?}. Retrying... ({connection_attempts}/{MAX_CONNECTION_ATTEMPTS})");
@@ -484,7 +580,7 @@ impl P2pNet {
                                                         }
                                                     } else {
                                                         // Show a message in case that the stream is already there.
-                                                        if streams_clone.insert(peer_id, Arc::new(Mutex::new(stream))).is_some() {
+                                                        if streams_clone.insert(peer_id, Arc::new(Mutex::new(buffered_stream))).is_some() {
                                                             error!(local_id = party_idx, "A stream with {peer_id} was already present in the database. The old stream will be dropped.")
                                                         }
                                                         info!(local_id = party_idx, "Correct ACK received. Peer successfully opened a stream with peer {peer_id}.");
@@ -529,7 +625,7 @@ impl P2pNet {
                         }
                     }
                     event = swarm.select_next_some() => {
-                        debug!(local_id = party_idx, "Peer received an incomming event to handle: {event:?}");
+                        debug!(local_id = party_idx, "Peer received an incoming event to handle: {event:?}");
                         // Spawn the event handler in a new task in case that handling the event is
                         // a very heavy task.
                         tokio::spawn(
@@ -660,7 +756,7 @@ impl P2pNet {
         own_id: usize,
         event: SwarmEvent<BehaviourEvent>,
         received_broadcasts: Sender<Message>,
-        streams: Arc<DashMap<PeerId, Arc<Mutex<Stream>>>>,
+        streams: Arc<DashMap<PeerId, Arc<Mutex<BufferedFramedStream>>>>,
         peer_ids: Arc<DashMap<usize, PeerId>>,
     ) -> Result<()> {
         match event {
@@ -683,7 +779,7 @@ impl P2pNet {
                 };
             }
             SwarmEvent::Behaviour(BehaviourEvent::Ping(event)) => {
-                info!("Received ping event: {event:?}");
+                debug!("Received ping event: {event:?}");
             }
             SwarmEvent::NewListenAddr { address, .. } => {
                 info!("Peer with ID {own_id} listening on {address:?}");
@@ -735,10 +831,8 @@ impl P2pNet {
         self.id
     }
 
-    /// Send a message to the peer.
     pub async fn send(&self, peer_id: usize, data: &[u8]) -> Result<usize> {
         let start = Instant::now();
-
         let peer_id_encoded = {
             *self
                 .peer_ids
@@ -746,26 +840,20 @@ impl P2pNet {
                 .ok_or(Error::PeerIdNotInDatabase(peer_id))?
         };
 
-        let bytes = {
-            let individual_stream_mutex = {
-                self.streams
-                    .get_mut(&peer_id_encoded)
-                    .ok_or(Error::StreamNotInDatabase(peer_id))?
-                    .clone()
-            };
-
-            let mut stream = individual_stream_mutex.lock().await;
-
-            stream.write(data).await.map_err(|error| Error::SendError {
-                receiver_id: peer_id_encoded,
-                error,
-            })?
+        let individual_stream_mutex = {
+            self.streams
+                .get_mut(&peer_id_encoded)
+                .ok_or(Error::StreamNotInDatabase(peer_id))?
+                .clone()
         };
-        self.stats.update_send(bytes, start.elapsed());
-        Ok(bytes)
+
+        let mut stream = individual_stream_mutex.lock().await;
+
+        stream.write(data).await?;
+        self.stats.update_send(data.len(), start.elapsed());
+        Ok(data.len())
     }
 
-    /// Receive a message from the peer.
     pub async fn recv(&self, peer_id: usize, buffer: &mut [u8]) -> Result<usize> {
         let own_id = self.id;
         info!("Peer {own_id} is receiving a message from {peer_id}");
@@ -777,26 +865,18 @@ impl P2pNet {
                 .ok_or(Error::PeerIdNotInDatabase(peer_id))?
         };
 
-        let bytes_read = {
-            let individual_stream_mutex = {
-                self.streams
-                    .get_mut(&peer_id_encoded)
-                    .ok_or(Error::StreamNotInDatabase(peer_id))?
-                    .clone()
-            };
-
-            let mut stream = individual_stream_mutex.lock().await;
-            stream
-                .read(buffer)
-                .await
-                .map_err(|error| Error::RecvError {
-                    sender_id: peer_id,
-                    error,
-                })?
+        let individual_stream_mutex = {
+            self.streams
+                .get_mut(&peer_id_encoded)
+                .ok_or(Error::StreamNotInDatabase(peer_id))?
+                .clone()
         };
 
-        self.stats.update_recv(bytes_read, start.elapsed());
-        Ok(bytes_read)
+        let mut stream = individual_stream_mutex.lock().await;
+        stream.read(buffer).await?;
+
+        self.stats.update_recv(buffer.len(), start.elapsed());
+        Ok(buffer.len())
     }
 
     /// Broadcast a message to all parties using the gossipsub protocol.
@@ -804,7 +884,7 @@ impl P2pNet {
         let own_id = self.id;
         info!("Broadcasting message from {own_id} using gossipsub");
         let init_time = Instant::now();
-        let (cmd_sender, cmd_receiver) = tokio::sync::oneshot::channel();
+        let (cmd_sender, cmd_receiver) = oneshot::channel();
         self.sender_swarm_commands
             .send(SwarmCommand::Broadcast {
                 data: data.to_vec(),
@@ -822,21 +902,10 @@ impl P2pNet {
         info!("Broadcasting message from {own_id} using raw broadcasting");
         for mut entry in self.streams.iter_mut() {
             let data = data.to_vec();
-            let peer_id = entry.key().clone();
             let stats = self.stats.clone();
             let init_time = Instant::now();
-            let bytes_sent =
-                entry
-                    .value_mut()
-                    .lock()
-                    .await
-                    .write(&data)
-                    .await
-                    .map_err(|error| Error::SendError {
-                        receiver_id: peer_id,
-                        error,
-                    })?;
-            stats.update_send(bytes_sent, init_time.elapsed());
+            entry.value_mut().lock().await.write(&data).await?;
+            stats.update_send(data.len(), init_time.elapsed());
         }
         Ok(())
     }
@@ -864,7 +933,7 @@ impl P2pNet {
 
     /// Flush all the streams in the network.
     pub async fn flush_all(&self) -> Result<()> {
-        let streams: Vec<Arc<Mutex<Stream>>> = {
+        let streams: Vec<Arc<Mutex<BufferedFramedStream>>> = {
             self.streams
                 .iter()
                 .map(|entry| entry.value().clone())
@@ -872,7 +941,7 @@ impl P2pNet {
         };
         for stream in streams {
             let mut stream_mutex = stream.lock().await;
-            stream_mutex.flush().await.map_err(Error::FlushError)?;
+            stream_mutex.flush().await?;
         }
         Ok(())
     }

--- a/network/tests/p2p.rs
+++ b/network/tests/p2p.rs
@@ -1,6 +1,7 @@
 use libp2p::identity::Keypair;
 use libp2p::{Multiaddr, PeerId};
 use network::p2p::{NodeConfig, P2pNet};
+use rand::Rng;
 use serial_test::serial;
 use std::str::FromStr;
 use std::sync::{Arc, Once};
@@ -18,6 +19,157 @@ pub fn setup_tracing() {
             .with_test_writer()
             .init();
     });
+}
+
+#[tokio::test]
+#[serial]
+async fn send_and_receive_multiple_values() {
+    setup_tracing();
+
+    const BASE_PORT: usize = 5000;
+    const NUM_PARTIES: usize = 10;
+    const NUM_VALUES: usize = 4096;
+
+    let mut prg = rand::thread_rng();
+    let values: Vec<u64> = (0..NUM_VALUES).map(|_| prg.gen()).collect();
+    let bytes = bytemuck::cast_slice(&values).to_vec();
+
+    // Generates the key pairs for each party.
+    let key_pairs = (0..NUM_PARTIES)
+        .map(|_| Keypair::generate_ed25519())
+        .collect::<Vec<_>>();
+
+    // Create threads for each party to simulate network communication.
+    let mut handles = Vec::new();
+    let (results_sx, mut results_rx) = tokio::sync::mpsc::channel(NUM_PARTIES + 2);
+
+    let start_barrier = Arc::new(Barrier::new(NUM_PARTIES));
+
+    for id in 0..NUM_PARTIES {
+        handles.push(tokio::spawn({
+            let key_pairs = key_pairs.clone();
+            let sender_channel = results_sx.clone();
+            let barrier = start_barrier.clone();
+            let bytes = bytes.clone();
+            let values = values.clone();
+            async move {
+                info!("Starting node {id}");
+                // Configure the node.
+                let (tx, _rx) = tokio::sync::mpsc::channel(100);
+                let listen_addr =
+                    Multiaddr::from_str(&format!("/ip4/127.0.0.1/tcp/{}", BASE_PORT + id)).unwrap();
+                let listen_addrs = vec![listen_addr];
+
+                // This block creates a vector of parties to dial
+                // in the following way:
+                //   [ party_0: (encoded_id_0, usize_id_0, addresses_to_dial_to_party_0) ]
+                //   [ party_1: (encoded_id_1, usize_id_1, addresses_to_dial_to_party_1) ]
+                //   ...
+                //   [ party_n: (encoded_id_n, usize_id_n, addresses_to_dial_to_party_n) ]
+                //
+                // Here, the encoded_id means the ID in the libp2p jargon, which is basically a
+                // hash of the public key.
+                let mut remote_peers = Vec::new();
+                for other_id in 0..NUM_PARTIES {
+                    if id != other_id {
+                        let dial_addr = Multiaddr::from_str(&format!(
+                            "/ip4/127.0.0.1/tcp/{}",
+                            BASE_PORT + other_id
+                        ))
+                        .unwrap();
+                        remote_peers.push((
+                            PeerId::from_public_key(&key_pairs[other_id].public()),
+                            other_id,
+                            vec![dial_addr],
+                        ));
+                    }
+                }
+
+                // Generate the node configuration.
+                let node_config = NodeConfig::new(listen_addrs, key_pairs[id].clone());
+
+                // Create the node and listen to the provided addresses.
+                let notifier_network_ready = Arc::new(tokio::sync::Notify::new());
+                let node = P2pNet::new(
+                    id,
+                    node_config,
+                    remote_peers,
+                    tx,
+                    notifier_network_ready.clone(),
+                    NUM_PARTIES,
+                )
+                .await
+                .expect("The node must be created correctly");
+
+                info!(local_id = id, "Waiting for all the nodes to open streams");
+                notifier_network_ready.notified().await;
+
+                for other_id in 0..NUM_PARTIES {
+                    if other_id != id {
+                        let send_result = node.send(other_id, &bytes).await;
+                        match send_result {
+                            Ok(bytes) => {
+                                info!(
+                                    "Message sent successfully from {:?} to {:?} with {:?} bytes",
+                                    id, other_id, bytes
+                                );
+                                node.flush(other_id)
+                                    .await
+                                    .expect("The message should be flushed");
+                            }
+                            Err(e) => {
+                                panic!(
+                                    "Error sending message from {:?} to {:?}: {:?}",
+                                    id, other_id, e
+                                );
+                            }
+                        }
+                    }
+                }
+
+                node.flush_all()
+                    .await
+                    .expect("All the messages should be flushed");
+
+                let mut n_received_msg = 0;
+                for other_id in 0..NUM_PARTIES {
+                    if other_id != id {
+                        let mut buffer = vec![0; bytes.len()];
+                        node.recv(other_id, &mut buffer).await.expect(
+                            "The message should be received as it was sent by the previous send",
+                        );
+                        assert_eq!(
+                            values,
+                            bytemuck::cast_slice(&buffer).to_vec(),
+                            "The received value are not the same as the original one"
+                        );
+                        n_received_msg += 1;
+                    }
+                }
+
+                sender_channel
+                    .send(n_received_msg)
+                    .await
+                    .expect("The process has finished so the message should be sent");
+
+                barrier.wait().await;
+                info!("Node process finished for peer {id}. Node will be destroyed.");
+            }
+        }));
+    }
+
+    for handle in handles {
+        handle.await.unwrap();
+    }
+
+    drop(results_sx);
+
+    // Check that each party received the same number of messages.
+    info!("Checking that each party received the same number of messages");
+    while let Some(num_received_msgs) = results_rx.recv().await {
+        assert_eq!(num_received_msgs, NUM_PARTIES - 1);
+    }
+    info!("All the parties received the same number of messages");
 }
 
 #[tokio::test]
@@ -96,7 +248,7 @@ async fn send_and_receive() {
                 info!(local_id = id, "Waiting for all the nodes to open streams");
                 notifier_network_ready.notified().await;
 
-                let message = format!("Hello from node {}", node.id());
+                let message = String::from("Hello from node");
                 for other_id in 0..NUM_PARTIES {
                     if other_id != id {
                         let send_result = node.send(other_id, message.as_bytes()).await;
@@ -127,7 +279,7 @@ async fn send_and_receive() {
                 let mut n_received_msg = 0;
                 for other_id in 0..NUM_PARTIES {
                     if other_id != id {
-                        let mut buffer = [0; 128];
+                        let mut buffer = vec![0; message.len()];
                         node.recv(other_id, &mut buffer).await.expect(
                             "The message should be received as it was sent by the previous send",
                         );
@@ -248,11 +400,11 @@ async fn raw_broadcast() {
                         .await
                         .expect("All the messages should be flushed");
                 } else {
-                    let mut buffer = [0; 128];
+                    let mut buffer = vec![0; message.len()];
                     node.recv(ID_BROADCAST_PARTY, &mut buffer).await.expect(
                         "The message should be received as it was sent by the previous send",
                     );
-                    assert_eq!(buffer[..message.len()], message.as_bytes()[..message.len()]);
+                    assert_eq!(buffer, message.as_bytes());
                     n_received_msg += 1;
                 }
 
@@ -488,7 +640,7 @@ async fn node_dropped_intentionally() {
                     return;
                 }
 
-                let message = format!("Hello from node {}", node.id());
+                let message = String::from("Hello from node");
                 for other_id in 0..NUM_PARTIES {
                     if other_id != id && other_id != ID_DROPPING_PARTY {
                         let send_result = node.send(other_id, message.as_bytes()).await;
@@ -519,7 +671,7 @@ async fn node_dropped_intentionally() {
                 let mut n_received_msg = 0;
                 for other_id in 0..NUM_PARTIES {
                     if other_id != id && other_id != ID_DROPPING_PARTY {
-                        let mut buffer = [0; 128];
+                        let mut buffer = vec![0; message.len()];
                         node.recv(other_id, &mut buffer).await.expect(
                             "The message should be received as it was sent by the previous send",
                         );

--- a/thfhe/examples/thfhe.rs
+++ b/thfhe/examples/thfhe.rs
@@ -10,7 +10,8 @@ use network::p2p::NodeConfig;
 use rand::SeedableRng;
 use std::str::FromStr;
 use thfhe::{distdec, Evaluator, Fp, KeyGen, DEFAULT_128_BITS_PARAMETERS};
-use tracing::error;
+use tracing::{error, info};
+use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::EnvFilter;
 
 const RING_MODULUS: u64 = Fp::MODULUS_VALUE;
@@ -22,7 +23,11 @@ pub fn setup_tracing() {
     INIT.call_once(|| {
         let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("off"));
         tracing_subscriber::fmt()
+            .with_target(false)
+            .with_level(true)
             .with_env_filter(filter)
+            .with_file(true)
+            .with_line_number(true)
             .with_test_writer()
             .init();
     });
@@ -47,6 +52,9 @@ struct Cli {
     /// Threshold for corrupted parties.
     #[arg(short = 't')]
     t: usize,
+    /// Number of triples required for the computation.
+    #[arg(short = 'r')]
+    triples: Option<usize>,
     /// Local execution or distributed execution.
     #[command(subcommand)]
     exec_type: ExecType,
@@ -58,6 +66,8 @@ async fn main() {
     let args = Cli::parse();
     let number_parties = args.n;
     let threshold = args.t;
+
+    let triples_required = args.triples.unwrap_or(100);
 
     if number_parties < threshold / 2 {
         error!(
@@ -115,6 +125,7 @@ async fn main() {
                         threshold,
                         node_config,
                         remote_peers,
+                        triples_required,
                     )
                     .await;
                 });
@@ -168,6 +179,7 @@ async fn main() {
                 threshold,
                 node_config,
                 participants,
+                triples_required,
             )
             .await;
         }
@@ -180,6 +192,7 @@ async fn thfhe(
     threshold: usize,
     node_config: NodeConfig,
     participants: Vec<(PeerId, usize, Vec<Multiaddr>)>,
+    triples_required: usize,
 ) {
     let start = std::time::Instant::now();
 
@@ -193,7 +206,7 @@ async fn thfhe(
         party_id,
         num_parties,
         threshold,
-        5600,
+        triples_required,
         node_config,
         participants,
         parameters.ring_dimension(),
@@ -204,15 +217,16 @@ async fn thfhe(
     .unwrap();
     let (sk, pk, evk) = KeyGen::generate_mpc_key_pair(&mut backend, **parameters, rng).await;
 
-    println!(
+    info!(
         "Party {:?} had finished keygen, NetInfo:{:?}",
         backend.party_id(),
         backend.netio.stats()
     );
     let evaluator = Evaluator::new(evk);
 
-    let test_total_num = [1, 10, 100, 1000];
+    let test_total_num = [1, 10];
 
+    info!("Generating triples");
     let ips = (0..num_parties)
         .map(|_| "127.0.0.1".to_string())
         .collect::<Vec<_>>();
@@ -221,7 +235,7 @@ async fn thfhe(
         num_parties,
         (BASE_PORT - 10500) as i32,
         &ips,
-        5600,
+        triples_required,
     )
     .unwrap();
 

--- a/thfhe/examples/thfhe.rs
+++ b/thfhe/examples/thfhe.rs
@@ -11,7 +11,6 @@ use rand::SeedableRng;
 use std::str::FromStr;
 use thfhe::{distdec, Evaluator, Fp, KeyGen, DEFAULT_128_BITS_PARAMETERS};
 use tracing::{error, info};
-use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::EnvFilter;
 
 const RING_MODULUS: u64 = Fp::MODULUS_VALUE;
@@ -197,7 +196,6 @@ async fn thfhe(
     let start = std::time::Instant::now();
 
     let rng = &mut rand::rngs::StdRng::seed_from_u64(1);
-
     let parameters = &DEFAULT_128_BITS_PARAMETERS;
     let lwe_params = parameters.input_lwe_params();
 

--- a/thfhe/src/key_gen.rs
+++ b/thfhe/src/key_gen.rs
@@ -1,5 +1,11 @@
+use std::fmt::Debug;
 use std::sync::Arc;
 
+use crate::{
+    generate_share_ntt_rlwe_ciphertext_vec, generate_shared_binary_slices,
+    generate_shared_lwe_ciphertext_vec, generate_shared_ternary_slices, EvaluationKey, Fp,
+    MPCSecretKeyPack, ThFheParameters,
+};
 use algebra::{
     decompose::NonPowOf2ApproxSignedBasis,
     polynomial::{FieldNttPolynomial, FieldPolynomial},
@@ -14,12 +20,7 @@ use itertools::izip;
 use lattice::{GadgetRlwe, Lwe, NttGadgetRlwe, NttRgsw, NttRlwe, Rgsw, Rlwe};
 use mpc::MPCBackend;
 use rand::{CryptoRng, Rng};
-
-use crate::{
-    generate_share_ntt_rlwe_ciphertext_vec, generate_shared_binary_slices,
-    generate_shared_lwe_ciphertext_vec, generate_shared_ternary_slices, EvaluationKey, Fp,
-    MPCSecretKeyPack, ThFheParameters,
-};
+use tracing::{info, info_span, instrument};
 
 /// Struct of key generation.
 pub struct KeyGen;
@@ -27,28 +28,23 @@ pub struct KeyGen;
 impl KeyGen {
     /// Generate key pair
     #[inline]
+    #[instrument(skip_all)]
     pub async fn generate_mpc_key_pair<Backend, R>(
         backend: &mut Backend,
         params: ThFheParameters,
         rng: &mut R,
     ) -> (MPCSecretKeyPack<Backend>, LwePublicKey<u64>, EvaluationKey)
     where
-        R: Rng + CryptoRng,
-
-        Backend: MPCBackend,
+        R: Rng + CryptoRng + Debug,
+        Backend: MPCBackend + Debug,
     {
+        info!("Starting key pair generation");
         let id = backend.party_id();
         let num_parties = backend.num_parties();
         let num_threshold = backend.num_threshold();
         let noise_number = num_parties - num_threshold;
 
-        //let start = std::time::Instant::now();
         let sk = MPCSecretKeyPack::new(backend, params).await;
-        // println!(
-        //     "Party {} had finished the secret key pack with time {:?}",
-        //     id,
-        //     start.elapsed()
-        // );
 
         let input_lwe_params = params.input_lwe_params();
         let key_switching_params = params.key_switching_params();
@@ -57,7 +53,6 @@ impl KeyGen {
         let start = std::time::Instant::now();
         let kappa = input_lwe_params.dimension
             * input_lwe_params.cipher_modulus_value.log_modulus() as usize;
-        // let kappa = input_lwe_params.cipher_modulus_value.log_modulus() as usize;
 
         let lwe_public_key: LwePublicKey<u64> = generate_lwe_public_key(
             backend,
@@ -69,12 +64,11 @@ impl KeyGen {
         .await
         .into();
 
-        println!(
+        info!(
             "Party {} had finished the lwe public key with time {:?}",
             id,
             start.elapsed()
         );
-        //println!("Party {:?} had finished lwe public key, NetInfo:{:?}",backend.party_id(),backend.netio.get_stats());
         backend.print_net_stats("had finished the lwe public key");
         let start = std::time::Instant::now();
         let key_switching_key_basis: NonPowOf2ApproxSignedBasis<u64> =
@@ -84,6 +78,7 @@ impl KeyGen {
                 key_switching_params.reverse_length,
             );
 
+        info!("Starting key switching key");
         let key_switching_key = generate_key_switching_key(
             backend,
             sk.input_lwe_secret_key.as_ref(),
@@ -94,12 +89,11 @@ impl KeyGen {
         )
         .await
         .to_fhe_ksk(key_switching_params, key_switching_key_basis);
-        println!(
+        info!(
             "Party {} had finished the key switching key with time {:?}",
             id,
             start.elapsed()
         );
-        //println!("Party {:?} had finished key switching key, NetInfo:{:?}",backend.party_id(),backend.netio.get_stats());
         backend.print_net_stats("had finished the key switching key");
 
         let start = std::time::Instant::now();
@@ -114,7 +108,7 @@ impl KeyGen {
         .await
         .to_fhe_binary_bsk(blind_rotation_params.dimension);
 
-        println!(
+        info!(
             "Party {} had finished the bootstrapping key with time {:?}",
             id,
             start.elapsed()
@@ -203,6 +197,7 @@ impl Into<LwePublicKey<u64>> for MPCLwePublicKey {
     }
 }
 
+#[instrument(skip_all)]
 pub async fn generate_lwe_public_key<Backend, R>(
     backend: &mut Backend,
     lwe_secret_key: &[Backend::Sharing],
@@ -214,6 +209,10 @@ where
     Backend: MPCBackend,
     R: Rng,
 {
+    info!(
+        id = backend.party_id(),
+        "Starting generation of LWE public key"
+    );
     let batch_mpc_lwe =
         generate_shared_lwe_ciphertext_vec(backend, lwe_secret_key, kappa, gaussian, rng).await;
     let b = backend
@@ -376,6 +375,7 @@ where
     Backend: MPCBackend,
     R: Rng,
 {
+    info!(id = backend.party_id(), "Generating bootstrapping key");
     let n = lwe_secret_key.len();
     let l = basis.decompose_length();
     let big_n = rlwe_secret_key.len();
@@ -425,14 +425,6 @@ where
                     });
             });
     }
-
-    // use itertools::Itertools;
-    // let b: Vec<u64> = batch_mpc_ntt_rlwe
-    //     .b
-    //     .as_slice()
-    //     .chunks_exact(big_n * 1024)
-    //     .map(|b_chunk| backend.reveal_slice_degree_2t_to_all(b_chunk).unwrap())
-    //     .concat();
 
     let mut a_iter = batch_mpc_ntt_rlwe.a.into_iter();
     let chunks = batch_mpc_ntt_rlwe.b.as_slice().chunks_exact(2 * l * big_n);

--- a/thfhe/src/key_gen.rs
+++ b/thfhe/src/key_gen.rs
@@ -78,7 +78,6 @@ impl KeyGen {
                 key_switching_params.reverse_length,
             );
 
-        info!("Starting key switching key");
         let key_switching_key = generate_key_switching_key(
             backend,
             sk.input_lwe_secret_key.as_ref(),
@@ -107,7 +106,6 @@ impl KeyGen {
         )
         .await
         .to_fhe_binary_bsk(blind_rotation_params.dimension);
-
         info!(
             "Party {} had finished the bootstrapping key with time {:?}",
             id,
@@ -219,6 +217,10 @@ where
         .reveal_slice_to_all(batch_mpc_lwe.b.as_slice())
         .await
         .unwrap();
+    info!(
+        id = backend.party_id(),
+        "Finished generation of LWE public key"
+    );
     MPCLwePublicKey(
         batch_mpc_lwe
             .a
@@ -363,6 +365,7 @@ impl MPCBootstrappingKey {
     }
 }
 
+#[instrument(skip_all)]
 pub async fn generate_bootstrapping_key<Backend, R>(
     backend: &mut Backend,
     lwe_secret_key: &[Backend::Sharing],
@@ -380,7 +383,7 @@ where
     let l = basis.decompose_length();
     let big_n = rlwe_secret_key.len();
 
-    println!("n: {}, l: {}, big_n: {}", n, l, big_n);
+    info!("n: {}, l: {}, big_n: {}", n, l, big_n);
 
     let basis_scalar = basis.scalar_iter().collect::<Vec<_>>();
 
@@ -442,7 +445,6 @@ where
     MPCNttBootstrappingKey(
         slices
             .into_iter()
-            // b.chunks_exact(2 * big_n * l)
             .map(|b_x| {
                 let (m_slice, minus_z_m_slice) = b_x.split_at(big_n * l);
                 RevealNttRgsw {
@@ -494,6 +496,7 @@ impl MPCKeySwitchingKey {
     }
 }
 
+#[instrument(skip_all)]
 pub async fn generate_key_switching_key<Backend, R>(
     backend: &mut Backend,
     input_secret_key: &[Backend::Sharing],
@@ -506,6 +509,7 @@ where
     Backend: MPCBackend,
     R: Rng,
 {
+    info!(id = backend.party_id(), "Starting key switching key");
     let n = input_secret_key.len();
     let l = basis.decompose_length();
 
@@ -526,6 +530,7 @@ where
 
     let mut a_iter = batch_mpc_lwe.a.into_iter();
 
+    info!(id = backend.party_id(), "Finished key switching key");
     MPCKeySwitchingKey(
         b.chunks_exact(n)
             .map(|b_x| {

--- a/thfhe/src/lwe.rs
+++ b/thfhe/src/lwe.rs
@@ -1,6 +1,8 @@
 use algebra::random::DiscreteGaussian;
 use mpc::MPCBackend;
 use rand::{prelude::Distribution, Rng};
+use std::fmt::Debug;
+use tracing::{info, instrument};
 
 #[derive(Debug, Clone, Default)]
 pub struct MPCLwe<Share: Default> {
@@ -23,6 +25,7 @@ pub struct BatchMPCLwe<Share: Default> {
     pub b: Vec<Share>,
 }
 
+#[instrument(skip_all)]
 pub async fn generate_shared_lwe_ciphertext_vec<Backend, R>(
     backend: &mut Backend,
     shared_secret_key: &[Backend::Sharing],
@@ -34,6 +37,7 @@ where
     Backend: MPCBackend,
     R: Rng,
 {
+    info!(id = backend.party_id(), "Generating shared LWE ciphertext");
     let mut batch_mpc_lwe = BatchMPCLwe {
         a: vec![vec![0; shared_secret_key.len()]; count],
         b: vec![Default::default(); count],
@@ -75,6 +79,7 @@ where
     Backend: MPCBackend,
     R: Rng,
 {
+    info!(id = backend.party_id(), "Generating shared LWE ciphertext");
     let id = backend.party_id();
     let mut a = vec![0; shared_secret_key.len()];
     backend.shared_rand_field_elements(&mut a);

--- a/thfhe/src/parameter/mod.rs
+++ b/thfhe/src/parameter/mod.rs
@@ -8,6 +8,7 @@ use algebra::Field;
 use algebra::NttField;
 use fhe_core::{FHECoreError, GadgetRlweParameters as BlindRotationParameters};
 use fhe_core::{KeySwitchingParameters, LweParameters, LweSecretKeyType, RingSecretKeyType};
+use tracing::info;
 
 mod constants;
 
@@ -330,7 +331,10 @@ impl ThFheParameters {
     /// Generates the NTT table.
     #[inline]
     pub fn generate_ntt_table_for_rlwe(&self) -> <Fp as NttField>::Table {
-        Fp::generate_ntt_table(self.ring_dimension().trailing_zeros()).unwrap()
+        info!("Generating NTT table for ring polynomials");
+        let table = Fp::generate_ntt_table(self.ring_dimension().trailing_zeros()).unwrap();
+        info!("NTT table for ring polynomials generated successfully");
+        table
     }
 
     /// Returns the key switching params of this [`BooleanFheParameters<C, Q>`].

--- a/thfhe/src/rlwe.rs
+++ b/thfhe/src/rlwe.rs
@@ -3,6 +3,7 @@ use std::vec;
 use algebra::random::DiscreteGaussian;
 use mpc::MPCBackend;
 use rand::{prelude::Distribution, Rng};
+use tracing::{info, instrument};
 
 pub struct MPCRlwe<Share> {
     pub a: Vec<u64>,
@@ -21,6 +22,7 @@ pub struct BatchMPCNttRlwe<Share: Default> {
     pub b: Vec<Share>,
 }
 
+#[instrument(skip_all)]
 pub async fn generate_share_ntt_rlwe_ciphertext_vec<Backend, R>(
     backend: &mut Backend,
     secret_key_share: &[Backend::Sharing],
@@ -33,14 +35,16 @@ where
     Backend: MPCBackend,
     R: Rng,
 {
+    info!(
+        id = backend.party_id(),
+        "Generating share NTT RLWE ciphertext vector"
+    );
     let polynomial_size = secret_key_share.len();
 
     let mut batch_mpc_rlwe = BatchMPCRlwe::<Backend::Sharing> {
         a: vec![vec![0; polynomial_size]; count],
         b: vec![Default::default(); count * polynomial_size],
     };
-    // count = 2 n l = 2 * 1024 * 8
-    // polynomial_size = 2024
 
     batch_mpc_rlwe.a.iter_mut().for_each(|a| {
         backend.shared_rand_field_elements(a);
@@ -68,7 +72,11 @@ where
     }
 
     let end = std::time::Instant::now();
-    println!("Share random e takes time: {:?}", end - start);
+    info!(
+        id = backend.party_id(),
+        "Share random e took time {:?}",
+        end - start
+    );
 
     batch_mpc_rlwe
         .a

--- a/thfhe/src/secret_key.rs
+++ b/thfhe/src/secret_key.rs
@@ -2,6 +2,7 @@ use std::{marker::PhantomData, sync::Arc};
 
 use algebra::{reduce::*, NttField};
 use mpc::MPCBackend;
+use tracing::info;
 
 use crate::{
     generate_shared_lwe_secret_key, generate_shared_rlwe_secret_key, Fp, MPCLweSecretKey,
@@ -47,7 +48,7 @@ where
                 intermediate_lwe_params.dimension(),
             )
             .await;
-        println!(
+        info!(
             "Party {} had finished the intermediate lwe secret key with time {:?}",
             id,
             start.elapsed()
@@ -62,7 +63,7 @@ where
                 blind_rotation_params.dimension,
             )
             .await;
-        println!(
+        info!(
             "Party {} had finished the rlwe secret key with time {:?}",
             id,
             start.elapsed()

--- a/thfhe/tests/key_gen.rs
+++ b/thfhe/tests/key_gen.rs
@@ -1,0 +1,99 @@
+use algebra::Field;
+use libp2p::identity::Keypair;
+use libp2p::{Multiaddr, PeerId};
+use mpc::DNBackend;
+use network::p2p::NodeConfig;
+use rand::SeedableRng;
+use std::str::FromStr;
+use thfhe::{Fp, KeyGen, DEFAULT_128_BITS_PARAMETERS};
+use tracing_subscriber::EnvFilter;
+
+const NUM_PARTIES: usize = 7;
+const THRESHOLD: usize = 3;
+const RING_MODULUS: u64 = Fp::MODULUS_VALUE;
+const TRIPLES_REQUIRED: usize = 100;
+
+static INIT: std::sync::Once = std::sync::Once::new();
+
+pub fn setup_tracing() {
+    INIT.call_once(|| {
+        let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("off"));
+        tracing_subscriber::fmt()
+            .with_target(false)
+            .with_level(true)
+            .with_env_filter(filter)
+            .with_file(true)
+            .with_line_number(true)
+            .with_test_writer()
+            .init();
+    });
+}
+
+#[tokio::test]
+async fn key_generation_correctness() {
+    setup_tracing();
+    const BASE_PORT: usize = 5400;
+
+    // Generates the key pairs for each party to establish the secure connections between them.
+    let key_pairs = (0..NUM_PARTIES)
+        .map(|_| Keypair::generate_ed25519())
+        .collect::<Vec<_>>();
+
+    let mut handles = Vec::new();
+    for party_id in 0..NUM_PARTIES {
+        let key_pairs = key_pairs.clone();
+        let handler = tokio::spawn(async move {
+            // Sets the information of the remote peers.
+            let mut remote_peers = Vec::new();
+            for other_id in 0..NUM_PARTIES {
+                if party_id != other_id {
+                    let dial_addr = Multiaddr::from_str(&format!(
+                        "/ip4/127.0.0.1/tcp/{}",
+                        BASE_PORT + other_id
+                    ))
+                    .unwrap();
+                    remote_peers.push((
+                        PeerId::from_public_key(&key_pairs[other_id].public()),
+                        other_id,
+                        vec![dial_addr],
+                    ));
+                }
+            }
+
+            // Establishes the listen addresses for the current peer.
+            let listen_addr =
+                Multiaddr::from_str(&format!("/ip4/127.0.0.1/tcp/{}", BASE_PORT + party_id))
+                    .unwrap();
+
+            let listen_addrs = vec![listen_addr];
+            let key_pair = key_pairs[party_id].clone();
+
+            // Generate the node configuration
+            let node_config = NodeConfig::new(listen_addrs, key_pair);
+
+            let rng = &mut rand::rngs::StdRng::seed_from_u64(1);
+            let parameters = &DEFAULT_128_BITS_PARAMETERS;
+
+            // Set up the DN backend.
+            let mut backend = DNBackend::<RING_MODULUS>::new(
+                party_id,
+                NUM_PARTIES,
+                THRESHOLD,
+                TRIPLES_REQUIRED,
+                node_config,
+                remote_peers,
+                parameters.ring_dimension(),
+                true,
+                true,
+            )
+            .await
+            .unwrap();
+            let (_, _, _) = KeyGen::generate_mpc_key_pair(&mut backend, **parameters, rng).await;
+        });
+        handles.push(handler);
+    }
+
+    for handler in handles {
+        handler.await.unwrap();
+    }
+}

--- a/thfhe/tests/key_gen.rs
+++ b/thfhe/tests/key_gen.rs
@@ -29,6 +29,7 @@ pub fn setup_tracing() {
     });
 }
 
+#[ignore]
 #[tokio::test]
 async fn key_generation_correctness() {
     setup_tracing();


### PR DESCRIPTION
# Overview

In this PR, I made two contributions: (1) started some tests for the key generation and corrected some issues, (2) implemented buffered framed streams for the network.

# Testing

The testing of the key generation is NOT complete. I wrote a basic test that does not `assert!`, on the contrary, it only tests that the key generation finishes. This means that if the tests pass, it does not guarantee that the keys are generated correctly. Adding `assert!` for this is necessary. Based on just that "completion" test, I corrected some issues in the implementation of DN07 due to some deadlocks.

# Buffered and framed streams

I wrapped the raw `Streams` from libp2p with a `BufferedFramedStream`. This new struct adds a buffered input to the stream so that the stream is not blocked that frequently. 

Additionally, to improve the transmission of data, I added framing to the stream. This means that when sending a message, the stream sends first the number of bytes in the message (as a `u32`) and then it sends the actual payload. This prevents the network from blocking a task with `read_exact`, but also prevents the network from receiving incomplete chunks of data when using the `read` function.